### PR TITLE
# EBIP-11: Upgrade Minting Oracle to 60 Minute TWA ETH/USD Price

### DIFF
--- a/protocol/contracts/ecosystem/oracles/UsdOracle.sol
+++ b/protocol/contracts/ecosystem/oracles/UsdOracle.sol
@@ -20,4 +20,8 @@ contract UsdOracle {
         return LibEthUsdOracle.getEthUsdPrice();
     }
 
+    function getEthUsdTwa(uint32 lookback) external view returns (uint256) {
+        return LibEthUsdOracle.getEthUsdPrice(lookback);
+    }
+
 }

--- a/protocol/contracts/ecosystem/oracles/UsdOracle.sol
+++ b/protocol/contracts/ecosystem/oracles/UsdOracle.sol
@@ -20,7 +20,7 @@ contract UsdOracle {
         return LibEthUsdOracle.getEthUsdPrice();
     }
 
-    function getEthUsdTwa(uint32 lookback) external view returns (uint256) {
+    function getEthUsdTwa(uint256 lookback) external view returns (uint256) {
         return LibEthUsdOracle.getEthUsdPrice(lookback);
     }
 

--- a/protocol/contracts/ecosystem/price/BeanstalkPrice.sol
+++ b/protocol/contracts/ecosystem/price/BeanstalkPrice.sol
@@ -15,6 +15,13 @@ contract BeanstalkPrice is CurvePrice, WellPrice {
         P.Pool[] ps;
     }
 
+    /**
+     * @notice Returns the non-manipulation resistant on-chain liquidiy, deltaB and price data for
+     * Bean in the following liquidity pools:
+     * - Curve Bean:3Crv Metapool
+     * - Constant Product Bean:Eth Well
+     * @dev No protocol should use this function to calculate manipulation resistant Bean price data.
+    **/
     function price() external view returns (Prices memory p) {
         p.ps = new P.Pool[](2);
         p.ps[0] = getCurve();

--- a/protocol/contracts/ecosystem/price/CurvePrice.sol
+++ b/protocol/contracts/ecosystem/price/CurvePrice.sol
@@ -33,6 +33,11 @@ contract CurvePrice {
     uint256 private constant j = 1;
     address[2] private tokens = [0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab, 0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490];
 
+    /**
+     * @notice Returns the non-manipulation resistant on-chain liquidiy, deltaB and price data for Bean
+     * in the Bean:3Crv Metapool.
+     * @dev No protocol should use this function to calculate manipulation resistant Bean price data.
+    **/
     function getCurve() public view returns (P.Pool memory pool) {
         pool.pool = POOL;
         pool.tokens = tokens;

--- a/protocol/contracts/ecosystem/price/WellPrice.sol
+++ b/protocol/contracts/ecosystem/price/WellPrice.sol
@@ -42,6 +42,11 @@ contract WellPrice {
         uint256 lpBdv;
     }
 
+    /**
+     * @notice Returns the non-manipulation resistant on-chain liquidiy, deltaB and price data for
+     * Bean a given Well.
+     * @dev No protocol should use this function to calculate manipulation resistant Bean price data.
+    **/
     function getConstantProductWell(address wellAddress) public view returns (P.Pool memory pool) {
         IWell well = IWell(wellAddress);
         pool.pool = wellAddress;

--- a/protocol/contracts/libraries/Minting/LibWellMinting.sol
+++ b/protocol/contracts/libraries/Minting/LibWellMinting.sol
@@ -33,7 +33,8 @@ library LibWellMinting {
 
     using SignedSafeMath for int256;
 
-    uint256 constant TURN_BACK_ON_SEASON = 16_665;
+    // One hour in seconds.
+    uint32 constant ONE_HOUR = 3600;
 
     /**
      * @notice Emitted when a Well Minting Oracle is captured.
@@ -106,10 +107,6 @@ library LibWellMinting {
     function initializeOracle(address well) internal {
         AppStorage storage s = LibAppStorage.diamondStorage();
 
-        if (s.season.current < TURN_BACK_ON_SEASON) {
-            return;
-        }
-
         // If pump has not been initialized for `well`, `readCumulativeReserves` will revert. 
         // Need to handle failure gracefully, so Sunrise does not revert.
         try ICumulativePump(C.BEANSTALK_PUMP).readCumulativeReserves(
@@ -170,7 +167,7 @@ library LibWellMinting {
             C.BYTES_ZERO
         ) returns (uint[] memory twaReserves, bytes memory snapshot) {
             IERC20[] memory tokens = IWell(well).tokens();
-            (uint256[] memory ratios, uint256 beanIndex, bool success) = LibWell.getRatiosAndBeanIndex(tokens);
+            (uint256[] memory ratios, uint256 beanIndex, bool success) = LibWell.getRatiosAndBeanIndex(tokens, ONE_HOUR);
 
             // If the Bean reserve is less than the minimum, the minting oracle should be considered off.
             if (twaReserves[beanIndex] < C.WELL_MINIMUM_BEAN_BALANCE) {

--- a/protocol/contracts/libraries/Minting/LibWellMinting.sol
+++ b/protocol/contracts/libraries/Minting/LibWellMinting.sol
@@ -33,9 +33,6 @@ library LibWellMinting {
 
     using SignedSafeMath for int256;
 
-    // One hour in seconds.
-    uint32 constant ONE_HOUR = 3600;
-
     /**
      * @notice Emitted when a Well Minting Oracle is captured.
      * @param season The season that the Well was captured.
@@ -167,7 +164,11 @@ library LibWellMinting {
             C.BYTES_ZERO
         ) returns (uint[] memory twaReserves, bytes memory snapshot) {
             IERC20[] memory tokens = IWell(well).tokens();
-            (uint256[] memory ratios, uint256 beanIndex, bool success) = LibWell.getRatiosAndBeanIndex(tokens, ONE_HOUR);
+            (
+                uint256[] memory ratios,
+                uint256 beanIndex,
+                bool success
+            ) = LibWell.getRatiosAndBeanIndex(tokens, block.timestamp.sub(s.season.timestamp));
 
             // If the Bean reserve is less than the minimum, the minting oracle should be considered off.
             if (twaReserves[beanIndex] < C.WELL_MINIMUM_BEAN_BALANCE) {

--- a/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
@@ -53,17 +53,92 @@ library LibChainlinkOracle {
         {
             // Check for an invalid roundId that is 0
             if (roundId == 0) return 0;
-            // Check for an invalid timeStamp that is 0, or in the future
-            if (timestamp == 0 || timestamp > block.timestamp) return 0;
-            // Check if Chainlink's price feed has timed out
-            if (block.timestamp.sub(timestamp) > CHAINLINK_TIMEOUT) return 0;
-            // Check for non-positive price
-            if (answer <= 0) return 0;
-            // Return the 
+            checkForInvalidTimestampOrAnswer(timestamp, answer);
+            // Adjust to 6 decimal precision.
             return uint256(answer).mul(PRECISION).div(10**decimals);
         } catch {
             // If call to Chainlink aggregator reverts, return a price of 0 indicating failure
             return 0;
         }
+    }
+
+    /**
+     * @dev Returns the TWAP ETH/USD price from the Chainlink Oracle over the past `lookback` seconds.
+     * Return value has 6 decimal precision.
+     * Returns 0 if Chainlink's price feed is broken or frozen.
+    **/
+    function getTwapEthUsdPrice(uint256 lookback) internal view returns (uint256 price) {
+        // First, try to get current decimal precision:
+        uint8 decimals;
+        try priceAggregator.decimals() returns (uint8 _decimals) {
+            // If call to Chainlink succeeds, record the current decimal precision
+            decimals = _decimals;
+        } catch {
+            // If call to Chainlink aggregator reverts, return a price of 0 indicating failure
+            return 0;
+        }
+
+        // Secondly, try to get latest price data:
+        try priceAggregator.latestRoundData() returns
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 /* startedAt */,
+            uint256 timestamp,
+            uint80 /* answeredInRound */
+        )
+        {
+            // Check for an invalid roundId that is 0
+            if (roundId == 0) return 0;
+            if (checkForInvalidTimestampOrAnswer(timestamp, answer)) {
+                return 0;
+            }
+
+            uint256 endTimestamp = block.timestamp.sub(lookback);
+            // Check if last round was more than `lookback` ago.
+            if (timestamp <= endTimestamp) {
+                return uint256(answer).mul(PRECISION).div(10**decimals);
+            } else {
+                uint256 cumulativePrice;
+                uint256 lastTimestamp = block.timestamp;
+                while(timestamp > endTimestamp) {
+                    cumulativePrice = cumulativePrice.add(uint256(answer).mul(lastTimestamp.sub(timestamp)));
+                    roundId -= 1;
+                    try priceAggregator.getRoundData(roundId) returns
+                    (
+                        uint80 /* roundId */,
+                        int256 _answer,
+                        uint256 /* startedAt */,
+                        uint256 _timestamp,
+                        uint80 /* answeredInRound */
+                    )
+                    {
+                        if (checkForInvalidTimestampOrAnswer(_timestamp, _answer)) {
+                            return 0;
+                        }
+                        lastTimestamp = timestamp;
+                        timestamp = _timestamp;
+                        answer = _answer;
+                    } catch {
+                        // If call to Chainlink aggregator reverts, return a price of 0 indicating failure
+                        return 0;
+                    }
+                }
+                cumulativePrice = cumulativePrice.add(uint256(answer).mul(lastTimestamp.sub(endTimestamp)));
+                return cumulativePrice.mul(PRECISION).div(10**decimals).div(lookback);
+            }
+        } catch {
+            // If call to Chainlink aggregator reverts, return a price of 0 indicating failure
+            return 0;
+        }
+    }
+
+    function checkForInvalidTimestampOrAnswer(uint256 timestamp, int256 answer) private view returns (bool) {
+        // Check for an invalid timeStamp that is 0, or in the future
+        if (timestamp == 0 || timestamp > block.timestamp) return true;
+        // Check if Chainlink's price feed has timed out
+        if (block.timestamp.sub(timestamp) > CHAINLINK_TIMEOUT) return true;
+        // Check for non-positive price
+        if (answer <= 0) return true;
     }
 }

--- a/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
@@ -65,6 +65,7 @@ library LibChainlinkOracle {
      * @dev Returns the TWAP ETH/USD price from the Chainlink Oracle over the past `lookback` seconds.
      * Return value has 6 decimal precision.
      * Returns 0 if Chainlink's price feed is broken or frozen.
+     * Supports a maximum lookback of 4 hours.
      **/
     function getEthUsdTwap(uint256 lookback) internal view returns (uint256 price) {
         // First, try to get current decimal precision:

--- a/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
@@ -67,7 +67,7 @@ library LibChainlinkOracle {
      * Return value has 6 decimal precision.
      * Returns 0 if Chainlink's price feed is broken or frozen.
     **/
-    function getTwapEthUsdPrice(uint256 lookback) internal view returns (uint256 price) {
+    function getEthUsdTwap(uint256 lookback) internal view returns (uint256 price) {
         // First, try to get current decimal precision:
         uint8 decimals;
         try priceAggregator.decimals() returns (uint8 _decimals) {

--- a/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
@@ -50,7 +50,7 @@ library LibChainlinkOracle {
         ) {
             // Check for an invalid roundId that is 0
             if (roundId == 0) return 0;
-            if (checkForInvalidTimestampOrAnswer(timestamp, answer)) {
+            if (checkForInvalidTimestampOrAnswer(timestamp, answer, block.timestamp)) {
                 return 0;
             }
             // Adjust to 6 decimal precision.
@@ -65,7 +65,6 @@ library LibChainlinkOracle {
      * @dev Returns the TWAP ETH/USD price from the Chainlink Oracle over the past `lookback` seconds.
      * Return value has 6 decimal precision.
      * Returns 0 if Chainlink's price feed is broken or frozen.
-     * Supports a maximum lookback of 4 hours.
      **/
     function getEthUsdTwap(uint256 lookback) internal view returns (uint256 price) {
         // First, try to get current decimal precision:
@@ -88,7 +87,7 @@ library LibChainlinkOracle {
         ) {
             // Check for an invalid roundId that is 0
             if (roundId == 0) return 0;
-            if (checkForInvalidTimestampOrAnswer(timestamp, answer)) {
+            if (checkForInvalidTimestampOrAnswer(timestamp, answer, block.timestamp)) {
                 return 0;
             }
 
@@ -111,7 +110,7 @@ library LibChainlinkOracle {
                         uint256 _timestamp,
                         uint80 /* answeredInRound */
                     ) {
-                        if (checkForInvalidTimestampOrAnswer(_timestamp, _answer)) {
+                        if (checkForInvalidTimestampOrAnswer(_timestamp, _answer, timestamp)) {
                             return 0;
                         }
                         lastTimestamp = timestamp;
@@ -131,11 +130,11 @@ library LibChainlinkOracle {
         }
     }
 
-    function checkForInvalidTimestampOrAnswer(uint256 timestamp, int256 answer) private view returns (bool) {
+    function checkForInvalidTimestampOrAnswer(uint256 timestamp, int256 answer, uint256 currentTimestamp) private view returns (bool) {
         // Check for an invalid timeStamp that is 0, or in the future
-        if (timestamp == 0 || timestamp > block.timestamp) return true;
+        if (timestamp == 0 || timestamp > currentTimestamp) return true;
         // Check if Chainlink's price feed has timed out
-        if (block.timestamp.sub(timestamp) > CHAINLINK_TIMEOUT) return true;
+        if (currentTimestamp.sub(timestamp) > CHAINLINK_TIMEOUT) return true;
         // Check for non-positive price
         if (answer <= 0) return true;
     }

--- a/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
@@ -50,7 +50,9 @@ library LibChainlinkOracle {
         ) {
             // Check for an invalid roundId that is 0
             if (roundId == 0) return 0;
-            checkForInvalidTimestampOrAnswer(timestamp, answer);
+            if (checkForInvalidTimestampOrAnswer(timestamp, answer)) {
+                return 0;
+            }
             // Adjust to 6 decimal precision.
             return uint256(answer).mul(PRECISION).div(10 ** decimals);
         } catch {

--- a/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibChainlinkOracle.sol
@@ -101,6 +101,8 @@ library LibChainlinkOracle {
             } else {
                 uint256 cumulativePrice;
                 uint256 lastTimestamp = block.timestamp;
+                // Loop through previous rounds and compute cumulative sum until
+                // a round at least `lookback` seconds ago is reached.
                 while(timestamp > endTimestamp) {
                     cumulativePrice = cumulativePrice.add(uint256(answer).mul(lastTimestamp.sub(timestamp)));
                     roundId -= 1;

--- a/protocol/contracts/libraries/Oracle/LibEthUsdOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibEthUsdOracle.sol
@@ -42,46 +42,28 @@ library LibEthUsdOracle {
     uint32 constant INSTANT_LOOKBACK = 900;
 
     /**
-     * @dev Returns the ETH/USD price.
+     * @dev Returns the instantaneous ETH/USD price
+     * Return value has 6 decimal precision.
+     * Returns 0 if the Eth Usd Oracle cannot fetch a manipulation resistant price.
+     **/
+    function getEthUsdPrice() internal view returns (uint256) {
+        return getEthUsdPrice(0);
+    }
+
+    /**
+     * @dev Returns the ETH/USD price with the option of using a TWA lookback.
+     * Use `lookback = 0` for the instantaneous price. `lookback > 0` for a TWAP.
      * Return value has 6 decimal precision.
      * Returns 0 if the Eth Usd Oracle cannot fetch a manipulation resistant price.
     **/
-    function getEthUsdPrice() internal view returns (uint256) {
+    function getEthUsdPrice(uint32 lookback) internal view returns (uint256) {
+        uint256 chainlinkPrice = lookback > 0 ?
+            LibChainlinkOracle.getEthUsdTwap(lookback) :
+            LibChainlinkOracle.getEthUsdPrice();
 
-        uint256 chainlinkPrice = LibChainlinkOracle.getEthUsdPrice();
-        // Check if the chainlink price is broken or frozen.
-        if (chainlinkPrice == 0) return 0;
+        // Use a lookback of 900 seconds for an instantaneous price query for manipulation resistance.
+        if (lookback == 0) lookback = INSTANT_LOOKBACK;
 
-        uint256 usdcPrice = LibUniswapOracle.getEthUsdcPrice(INSTANT_LOOKBACK);
-        uint256 usdcChainlinkPercentDiff = getPercentDifference(usdcPrice, chainlinkPrice);
-
-        // Check if the USDC price and the Chainlink Price are sufficiently close enough
-        // to warrant using the greedy approach.
-        if (usdcChainlinkPercentDiff < MAX_GREEDY_DIFFERENCE) {
-            return chainlinkPrice.add(usdcPrice).div(2);
-        }
-
-        uint256 usdtPrice = LibUniswapOracle.getEthUsdtPrice(INSTANT_LOOKBACK);
-        uint256 usdtChainlinkPercentDiff = getPercentDifference(usdtPrice, chainlinkPrice);
-
-        // Check whether the USDT or USDC price is closer to the Chainlink price.
-        if (usdtChainlinkPercentDiff < usdcChainlinkPercentDiff) {
-            // Check whether the USDT price is too far from the Chainlink price.
-            if (usdtChainlinkPercentDiff < MAX_DIFFERENCE) {
-                return chainlinkPrice.add(usdtPrice).div(2);
-            }
-            return chainlinkPrice;
-        } else {
-            // Check whether the USDC price is too far from the Chainlink price.
-            if (usdcChainlinkPercentDiff < MAX_DIFFERENCE) {
-                return chainlinkPrice.add(usdcPrice).div(2);
-            }
-            return chainlinkPrice;
-        }
-    }
-
-    function getEthUsdTwap(uint32 lookback) internal view returns (uint256) {
-        uint256 chainlinkPrice = LibChainlinkOracle.getTwapEthUsdPrice(lookback);
         // Check if the chainlink price is broken or frozen.
         if (chainlinkPrice == 0) return 0;
 

--- a/protocol/contracts/libraries/Oracle/LibUniswapOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUniswapOracle.sol
@@ -18,10 +18,6 @@ import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
  **/
 library LibUniswapOracle {
 
-    // The lookback in seconds for which to calculate the SMA in a Uniswap V3 pool.
-    // Set to 15 minutes
-    uint32 constant PERIOD = 900;
-
     uint128 constant ONE_WETH = 1e18;
 
     /**
@@ -29,8 +25,8 @@ library LibUniswapOracle {
      * Return value has 6 decimal precision.
      * Returns 0 if {IUniswapV3Pool.observe} reverts.
      */
-    function getEthUsdcPrice() internal view returns (uint256 price) {
-        (bool success, int24 tick) = consult(C.UNIV3_ETH_USDC_POOL, PERIOD);
+    function getEthUsdcPrice(uint32 lookback) internal view returns (uint256 price) {
+        (bool success, int24 tick) = consult(C.UNIV3_ETH_USDC_POOL, lookback);
         if (!success) return 0;
         price = OracleLibrary.getQuoteAtTick(tick, ONE_WETH, C.WETH, C.USDC);
     }
@@ -40,8 +36,8 @@ library LibUniswapOracle {
      * Return value has 6 decimal precision.
      * Returns 0 if {IUniswapV3Pool.observe} reverts.
      */
-    function getEthUsdtPrice() internal view returns (uint256 price) {
-        (bool success, int24 tick) = consult(C.UNIV3_ETH_USDT_POOL, PERIOD);
+    function getEthUsdtPrice(uint32 lookback) internal view returns (uint256 price) {
+        (bool success, int24 tick) = consult(C.UNIV3_ETH_USDT_POOL, lookback);
         if (!success) return 0;
         price = OracleLibrary.getQuoteAtTick(tick, ONE_WETH, C.WETH, C.USDT);
     }

--- a/protocol/contracts/libraries/Oracle/LibUniswapOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUniswapOracle.sol
@@ -24,6 +24,9 @@ library LibUniswapOracle {
      * @dev Uses the Uniswap V3 Oracle to get the price of ETH denominated in USDC.
      * Return value has 6 decimal precision.
      * Returns 0 if {IUniswapV3Pool.observe} reverts.
+     * It is recommended to use a substantially large `lookback` (at least 900 seconds) to protect
+     * against manipulation.
+     * Note: Uniswap V3 pool oracles are not multi-block MEV resistant.
      */
     function getEthUsdcPrice(uint32 lookback) internal view returns (uint256 price) {
         (bool success, int24 tick) = consult(C.UNIV3_ETH_USDC_POOL, lookback);

--- a/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
@@ -19,28 +19,20 @@ library LibUsdOracle {
 
     using SafeMath for uint256;
 
-    /**
-     * @dev Returns the price of a given token in in USD.
-     */
     function getUsdPrice(address token) internal view returns (uint256) {
-        if (token == C.WETH) {
-            uint256 ethUsdPrice = LibEthUsdOracle.getEthUsdPrice();
-            if (ethUsdPrice == 0) return 0;
-            return uint256(1e24).div(ethUsdPrice);
-        }
-        revert("Oracle: Token not supported.");
+        return getUsdPrice(token, 0);
     }
 
     /**
-     * @dev Returns the TWA price of a given token in in USD.
+     * @dev Returns the price of a given token in in USD with the option of using a lookback.
+     * `lookback` should be 0 if the instantaneous price is desired. Otherwise, the TWAP lookback in seconds.
      */
-    function getUsdTwap(address token, uint32 lookback) internal view returns (uint256) {
+    function getUsdPrice(address token, uint32 lookback) internal view returns (uint256) {
         if (token == C.WETH) {
-            uint256 ethUsdPrice = LibEthUsdOracle.getEthUsdTwap(lookback);
+            uint256 ethUsdPrice = LibEthUsdOracle.getEthUsdPrice(lookback);
             if (ethUsdPrice == 0) return 0;
             return uint256(1e24).div(ethUsdPrice);
         }
         revert("Oracle: Token not supported.");
     }
-
 }

--- a/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
@@ -31,4 +31,16 @@ library LibUsdOracle {
         revert("Oracle: Token not supported.");
     }
 
+    /**
+     * @dev Returns the TWA price of a given token in in USD.
+     */
+    function getUsdTwap(address token, uint32 lookback) internal view returns (uint256) {
+        if (token == C.WETH) {
+            uint256 ethUsdPrice = LibEthUsdOracle.getEthUsdTwap(lookback);
+            if (ethUsdPrice == 0) return 0;
+            return uint256(1e24).div(ethUsdPrice);
+        }
+        revert("Oracle: Token not supported.");
+    }
+
 }

--- a/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
+++ b/protocol/contracts/libraries/Oracle/LibUsdOracle.sol
@@ -25,9 +25,12 @@ library LibUsdOracle {
 
     /**
      * @dev Returns the price of a given token in in USD with the option of using a lookback.
-     * `lookback` should be 0 if the instantaneous price is desired. Otherwise, the TWAP lookback in seconds.
+     * `lookback` should be 0 if the instantaneous price is desired. Otherwise, it should be the
+     * TWAP lookback in seconds.
+     * If using a non-zero lookback, it is recommended to use a substantially large `lookback`
+     * (> 900 seconds) to protect against manipulation.
      */
-    function getUsdPrice(address token, uint32 lookback) internal view returns (uint256) {
+    function getUsdPrice(address token, uint256 lookback) internal view returns (uint256) {
         if (token == C.WETH) {
             uint256 ethUsdPrice = LibEthUsdOracle.getEthUsdPrice(lookback);
             if (ethUsdPrice == 0) return 0;

--- a/protocol/contracts/libraries/Well/LibWell.sol
+++ b/protocol/contracts/libraries/Well/LibWell.sol
@@ -34,7 +34,7 @@ library LibWell {
      * @dev Returns the price ratios between `tokens` and the index of Bean in `tokens`.
      * These actions are combined into a single function for gas efficiency.
      */
-    function getRatiosAndBeanIndex(IERC20[] memory tokens, uint32 lookback) internal view returns (
+    function getRatiosAndBeanIndex(IERC20[] memory tokens, uint256 lookback) internal view returns (
         uint[] memory ratios,
         uint beanIndex,
         bool success

--- a/protocol/contracts/libraries/Well/LibWell.sol
+++ b/protocol/contracts/libraries/Well/LibWell.sol
@@ -22,11 +22,19 @@ library LibWell {
 
     using SafeMath for uint256;
 
+    function getRatiosAndBeanIndex(IERC20[] memory tokens) internal view returns (
+        uint[] memory ratios,
+        uint beanIndex,
+        bool success
+    ) {
+        return getRatiosAndBeanIndex(tokens, 0);
+    }
+
     /**
      * @dev Returns the price ratios between `tokens` and the index of Bean in `tokens`.
      * These actions are combined into a single function for gas efficiency.
      */
-    function getRatiosAndBeanIndex(IERC20[] memory tokens) internal view returns (
+    function getRatiosAndBeanIndex(IERC20[] memory tokens, uint32 lookback) internal view returns (
         uint[] memory ratios,
         uint beanIndex,
         bool success
@@ -39,7 +47,7 @@ library LibWell {
                 beanIndex = i;
                 ratios[i] = 1e6;
             } else {
-                ratios[i] = LibUsdOracle.getUsdPrice(address(tokens[i]));
+                ratios[i] = LibUsdOracle.getUsdPrice(address(tokens[i]), lookback);
                 if (ratios[i] == 0) {
                     success = false;
                 }

--- a/protocol/contracts/mocks/chainlink/MockChainlinkAggregator.sol
+++ b/protocol/contracts/mocks/chainlink/MockChainlinkAggregator.sol
@@ -82,6 +82,19 @@ contract MockChainlinkAggregator is IChainlinkAggregator {
         answeredInRounds[lastRound] = answeredInRound;
     }
 
+    function setRound(
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) external {
+        answers[roundId] = answer;
+        startedAts[roundId] = startedAt;
+        updatedAts[roundId] = updatedAt;
+        answeredInRounds[roundId] = answeredInRound;
+    }
+
     function setDecimals(
         uint8 __decimals
     ) external {

--- a/protocol/contracts/mocks/chainlink/MockChainlinkAggregator.sol
+++ b/protocol/contracts/mocks/chainlink/MockChainlinkAggregator.sol
@@ -40,6 +40,8 @@ contract MockChainlinkAggregator is IChainlinkAggregator {
             uint80 answeredInRound
         )
     {
+        if (_roundId > lastRound) revert();
+        if (_roundId == 0) revert();
         roundId = _roundId;
         answer = answers[_roundId];
         startedAt = startedAts[_roundId];
@@ -59,6 +61,7 @@ contract MockChainlinkAggregator is IChainlinkAggregator {
             uint80 answeredInRound
         )
     {
+        if (lastRound == 0) revert();
         roundId = lastRound;
         answer = answers[lastRound];
         startedAt = startedAts[lastRound];

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -357,6 +357,6 @@ contract MockSeasonFacet is SeasonFacet {
     }
 
     function getChainlinkTwapEthUsdPrice(uint256 lookback) external view returns (uint256) {
-        return LibChainlinkOracle.getTwapEthUsdPrice(lookback);
+        return LibChainlinkOracle.getEthUsdTwap(lookback);
     }
 }

--- a/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
+++ b/protocol/contracts/mocks/mockFacets/MockSeasonFacet.sol
@@ -345,14 +345,18 @@ contract MockSeasonFacet is SeasonFacet {
     }
 
     function getEthUsdcPrice() external view returns (uint256) {
-        return LibUniswapOracle.getEthUsdcPrice();
+        return LibUniswapOracle.getEthUsdcPrice(900);
     }
 
     function getEthUsdtPrice() external view returns (uint256) {
-        return LibUniswapOracle.getEthUsdtPrice();
+        return LibUniswapOracle.getEthUsdtPrice(900);
     }
 
     function getChainlinkEthUsdPrice() external view returns (uint256) {
         return LibChainlinkOracle.getEthUsdPrice();
+    }
+
+    function getChainlinkTwapEthUsdPrice(uint256 lookback) external view returns (uint256) {
+        return LibChainlinkOracle.getTwapEthUsdPrice(lookback);
     }
 }

--- a/protocol/hardhat.config.js
+++ b/protocol/hardhat.config.js
@@ -37,7 +37,7 @@ const { to6 } = require("./test/utils/helpers.js");
 const { task } = require("hardhat/config");
 const { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } = require("hardhat/builtin-tasks/task-names");
 const { bipNewSilo, mockBeanstalkAdmin } = require("./scripts/bips.js");
-const { ebip9, ebip10 } = require("./scripts/ebips.js");
+const { ebip9, ebip10, ebip11 } = require("./scripts/ebips.js");
 
 //////////////////////// UTILITIES ////////////////////////
 
@@ -221,6 +221,10 @@ task("migrate-bip38", async function () {
   await bipMigrateUnripeBean3CrvToBeanEth();
   await finishBeanEthMigration();
 });
+
+task("ebip11", async function () {
+  await ebip11();
+})
 
 task("ebip10", async function () {
   await ebip10();

--- a/protocol/scripts/diamond.js
+++ b/protocol/scripts/diamond.js
@@ -473,7 +473,7 @@ async function upgradeWithNewFacets ({
       }
     }
 
-    if (initFacetAddress !== undefined) {
+    if (initFacetAddress !== ethers.constants.AddressZero) {
       initFacet = await ethers.getContractAt(initFacetName, initFacetAddress)
     } else if (!initFacet) {
       const InitFacet = await ethers.getContractFactory(initFacetName, account)

--- a/protocol/scripts/diamond.js
+++ b/protocol/scripts/diamond.js
@@ -473,7 +473,9 @@ async function upgradeWithNewFacets ({
       }
     }
 
-    if (!initFacet) {
+    if (initFacetAddress !== undefined) {
+      initFacet = await ethers.getContractAt(initFacetName, initFacetAddress)
+    } else if (!initFacet) {
       const InitFacet = await ethers.getContractFactory(initFacetName, account)
       initFacet = await InitFacet.deploy()
       await initFacet.deployed()

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -98,6 +98,9 @@ async function ebip11(mock = true, account = undefined) {
   await upgradeWithNewFacets({
     diamondAddress: BEANSTALK,
     facetNames: ["SeasonFacet"],
+    initFacetName: 'InitMint',
+    initArgs: ['0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5', '4194934459'],
+    initFacetAddress: '0x077495925c17230E5e8951443d547ECdbB4925Bb',
     bip: false,
     object: !mock,
     verbose: true,

--- a/protocol/scripts/ebips.js
+++ b/protocol/scripts/ebips.js
@@ -89,6 +89,22 @@ async function ebip10(mock = true, account = undefined) {
   });
 }
 
+async function ebip11(mock = true, account = undefined) {
+  if (account == undefined) {
+    account = await impersonateBeanstalkOwner();
+    await mintEth(account.address);
+  }
+
+  await upgradeWithNewFacets({
+    diamondAddress: BEANSTALK,
+    facetNames: ["SeasonFacet"],
+    bip: false,
+    object: !mock,
+    verbose: true,
+    account: account
+  });
+}
+
 async function bipDiamondCut(name, dc, account, mock = true) {
   beanstalk = await getBeanstalk();
   if (mock) {
@@ -111,3 +127,4 @@ exports.ebip7 = ebip7;
 exports.ebip8 = ebip8;
 exports.ebip9 = ebip9;
 exports.ebip10 = ebip10;
+exports.ebip11 = ebip11

--- a/protocol/test/ChainlinkTwapOracle.test.js
+++ b/protocol/test/ChainlinkTwapOracle.test.js
@@ -1,0 +1,113 @@
+const { expect } = require('chai');
+const { deploy } = require('../scripts/deploy.js');
+const { getAltBeanstalk, getBean } = require('../utils/contracts.js');
+const { to6 } = require('./utils/helpers.js');
+const { takeSnapshot, revertToSnapshot } = require("./utils/snapshot.js");
+const { toBN } = require('../utils/helpers.js');
+const { setEthUsdPrice } = require('../utils/oracle.js');
+const { ETH_USD_CHAINLINK_AGGREGATOR } = require('./utils/constants.js');
+
+let user, user2, owner;
+
+let timestamp;
+
+async function setToSecondsAfterHour(seconds = 0) {
+    const lastTimestamp = (await ethers.provider.getBlock('latest')).timestamp;
+    const hourTimestamp = parseInt(lastTimestamp/3600 + 1) * 3600 + seconds
+    await network.provider.send("evm_setNextBlockTimestamp", [hourTimestamp])
+}
+
+async function checkPriceWithError(price, error = '1000000') {
+    expect(await season.getEthUsdPrice()).to.be.within(
+        to6(price).sub(toBN(error).div('2')),
+        to6(price).add(toBN(error).div('2'))
+    ) // Expected Rounding error
+}
+
+describe('TWAP Chainlink Oracle', function () {
+    before(async function () {
+        [owner, user, user2] = await ethers.getSigners();
+        const contracts = await deploy("Test", false, true);
+        season = await ethers.getContractAt('MockSeasonFacet', contracts.beanstalkDiamond.address)
+        beanstalk = await getAltBeanstalk(contracts.beanstalkDiamond.address)
+        bean = await getBean()
+        await setToSecondsAfterHour(0)
+        await owner.sendTransaction({to: user.address, value: 0})
+
+        ethUsdChainlinkAggregator = await ethers.getContractAt('MockChainlinkAggregator', ETH_USD_CHAINLINK_AGGREGATOR)
+
+        timestamp = (await ethers.provider.getBlock('latest')).timestamp
+    })
+
+    beforeEach(async function () {
+        snapshotId = await takeSnapshot();
+    });
+    
+    afterEach(async function () {
+        await revertToSnapshot(snapshotId);
+    });
+
+
+    it('returns 0 if no rounds', async function () {
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('0')
+    })
+
+    it('reverts if timeout', async function () {
+        await ethUsdChainlinkAggregator.addRound('0', timestamp-14500, timestamp-14500, '1')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('0')
+    })
+
+    it('returns 0 if failed rounds', async function () {
+        await ethUsdChainlinkAggregator.addRound('0', timestamp-3500, timestamp-3500, '1')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('0')
+    })
+    
+    it('returns 0 if no round > lookback ago', async function () {
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-3500, timestamp-3500, '1')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('0')
+    })
+
+    it('returns 0 if invalid timestamp', async function () {
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp+100, timestamp+100, '1')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('0')
+    })
+
+    it('returns 0 if older invalid round', async function () {
+        await ethUsdChainlinkAggregator.addRound('0', timestamp-3500, timestamp-3500, '1')
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-1800, timestamp-1800, '1')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('0')
+    })
+
+    it('returns 0 if multiple rounds, but no round > lookback ago', async function () {
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-3500, timestamp-3500, '1')
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-3400, timestamp-3500, '1')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('0')
+    })
+
+    it('reports result if last round is older than lookback', async function () {
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-4000, timestamp-4000, '1')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('10000')
+    })
+
+    it('reports average of 2 rounds', async function () {
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-4000, timestamp-4000, '1')
+        await ethUsdChainlinkAggregator.addRound('15000', timestamp-1798, timestamp-1798, '2')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('12500')
+    })
+
+    it('reports average of 3 rounds', async function () {
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-4000, timestamp-4000, '1')
+        await ethUsdChainlinkAggregator.addRound('15000', timestamp-1797, timestamp-1797, '2')
+        await ethUsdChainlinkAggregator.addRound('25000', timestamp-897, timestamp-897, '3')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('15000')
+    })
+
+    it('reports average of 4 rounds with an old round', async function () {
+        await ethUsdChainlinkAggregator.addRound('8000', timestamp-5000, timestamp-5000, '1')
+        await ethUsdChainlinkAggregator.addRound('10000', timestamp-4000, timestamp-4000, '2')
+        await ethUsdChainlinkAggregator.addRound('12500', timestamp-2695, timestamp-2695, '3')
+        await ethUsdChainlinkAggregator.addRound('15000', timestamp-1795, timestamp-1795, '3')
+        await ethUsdChainlinkAggregator.addRound('17500', timestamp-895, timestamp-895, '4')
+        expect(await season.getChainlinkTwapEthUsdPrice('3600')).to.be.equal('13750')
+    })
+})

--- a/protocol/test/Season.test.js
+++ b/protocol/test/Season.test.js
@@ -79,7 +79,7 @@ describe('Season', function () {
 
             await setToSecondsAfterHour(0)
             await beanstalk.connect(owner).sunrise();
-            expect(await bean.balanceOf(owner.address)).to.be.within('10700000', '10800000')
+            expect(await bean.balanceOf(owner.address)).to.be.within('10500000', '10600000')
         })
     })
 
@@ -95,7 +95,7 @@ describe('Season', function () {
             await beanstalk.connect(user).sunrise();
             await setToSecondsAfterHour(0)  
             await beanstalk.connect(owner).sunrise();
-            expect(await bean.balanceOf(owner.address)).to.be.within('10500000', '10600000')
+            expect(await bean.balanceOf(owner.address)).to.be.within('10200000', '10300000')
         })
     })
 })

--- a/protocol/test/Season.test.js
+++ b/protocol/test/Season.test.js
@@ -70,7 +70,7 @@ describe('Season', function () {
     })
 
     describe("oracle not initialized, previous balance > 0", async function () {
-        it.skip('season incentive', async function () {
+        it('season incentive', async function () {
             this.beanMetapool = await ethers.getContractAt('MockMeta3Curve', BEAN_3_CURVE);
             await this.beanMetapool.set_A_precise('1000');
             await this.beanMetapool.set_virtual_price(ethers.utils.parseEther('1'));
@@ -84,7 +84,7 @@ describe('Season', function () {
     })
 
     describe("oracle initialized", async function () {
-        it.skip('season incentive', async function () {
+        it('season incentive', async function () {
             this.beanMetapool = await ethers.getContractAt('MockMeta3Curve', BEAN_3_CURVE);
             await this.beanMetapool.set_A_precise('1000');
             await this.beanMetapool.set_virtual_price(ethers.utils.parseEther('1'));


### PR DESCRIPTION
Committed: October TBD, 2023

---

- [Submitter](#submitter)
- [Emergency Process Note](#emergency-process-note)
- [Links](#links)
- [Problem](#problem)
- [Solution](#solution)
- [Contract Changes](#contract-changes)
- [Effective](#effective)

## Submitter

Beanstalk Community Multisig

## Summary

* Add support for querying a time weighted average (TWA) ETH/USD price from Chainlink;
* Change the Chainlink component of the ETH/USD minting oracle from an instantaneous price to a 60 minute TWA price;
* Change the Uniswap V3 component of the ETH/USD minting oracle from 15 minute TWA prices to 60 minute TWA prices; and
* Mint 4194.934459 Beans to recapitalize the Beanstalk contract as a result of the issue fixed in EBIP-10.

## Links

Per the process outlined in the [BCM Emergency Response Procedures](https://docs.bean.money/almanac/governance/beanstalk/bcm-process#emergency-response-procedures), the BCM can take swift action to protect Beanstalk in the event of a bug or security vulnerability.

- [EBIP-11 GitHub PR](TBD)
- GitHub Commit Hash: [TBD](TBD)
- [Safe Transaction](TBD)
- [Etherscan Transaction](TBD)

## Problem

### TWA Chainlink Price

Prior to this EBIP, Beanstalk did not support querying a TWA price from the ETH/USD Chainlink data feed.

### Change ETH/USD Minting Oracle

Since [BIP-37](https://bean.money/bip-37) was committed, and prior to this EBIP, when determining how many Beans/Soil to mint, Beanstalk calculated the price of ETH in USD using the instantaneous price from the Chainlink ETH/USD data feed and compared it 15 minute TWA prices in the ETH:USDC and ETH:USDT 0.05% fee Uniswap V3 pools. 

When minting Beans during a `gm` call, Beanstalk compared this USD price of ETH with the TWA reserves of Beans and ETH in Multi Flow to calculate the TWA deltaB in the BEANETH Well. Because the Chainlink price in the former was not time weighted, the TWA deltaB calculated at the end of the Season would be higher than necessary if the ETH price was increasing. Similarly, the TWA deltaB calculated at the end of the Season would be lower than necessary if the ETH price was decreasing.

### Removed Beans from EBIP-10 Issue

As a result of the issue fixed in EBIP-10, about 33,049.986249 excess Beans were removed from the Beanstalk contract. About 28,855.05179 of these Beans were returned by the Farmers who Converted extra Beans as a result of the issue, resulting in a difference of 4,194.934459 Beans that are still missing from Beanstalk.

## Solution

All changes were reviewed by Cyfrin.

### TWA Chainlink Price

Add support for querying a time weighted average (TWA) ETH/USD price from Chainlink.

### Change ETH/USD Minting Oracle

Upgrade the ETH/USD price that the Well minting oracle uses to:
* 60 minute TWA price from the ETH/USD Chainlink data feed; and
* 60 minute TWA prices from the ETH:USDC and ETH:USDT 0.05% fee Uniswap V3 pools. 

### Removed Beans from EBIP-10 Issue

Mint the remaining 4,194.934459 Beans to the Beanstalk contract.

## Contract Changes

### Initialization Contract

The `init` function on the following `InitMint` contract is called:

- [`0x077495925c17230E5e8951443d547ECdbB4925Bb`](https://etherscan.io/address/0x077495925c17230E5e8951443d547ECdbB4925Bb#code)

### Season Facet

The following `SeasonFacet` is removed from Beanstalk:
* [`0x49435d19a5dcf8ffe8a4ea5c310758784d3f4561`](https://etherscan.io/address/0x49435d19a5dcf8ffe8a4ea5c310758784d3f4561#code)

The following `SeasonFacet` is added to Beanstalk:
* [`0x5eAfF0d247ee998bb4827B24292EAdC7f14f3EfC`](https://etherscan.io/address/0x5eAfF0d247ee998bb4827B24292EAdC7f14f3EfC#code)

#### `SeasonFacet` Function Changes

| Name                         | Selector     | Action  | Type | New Functionality |
|:-----------------------------|:-------------|:--------|:-----|:------------------|
| `abovePeg`                   | `0x2a27c499` | Replace | View |                   |
| `curveOracle`                | `0x07a3b202` | Replace | View |                   |
| `paused`                     | `0x5c975abb` | Replace | View |                   |
| `plentyPerRoot`              | `0xe60d7a83` | Replace | View |                   |
| `poolDeltaB`                 | `0x471bcdbe` | Replace | View |                   |
| `rain`                       | `0x43def26e` | Replace | View |                   |
| `season`                     | `0xc50b0fb0` | Replace | View |                   |
| `seasonTime`                 | `0xca7b7d7b` | Replace | View |                   |
| `sunriseBlock`               | `0x3b2ecb70` | Replace | View |                   |
| `time`                       | `0x16ada547` | Replace | View |                   |
| `totalDeltaB`                | `0x06c499d8` | Replace | View |                   |
| `weather`                    | `0x686b6159` | Replace | View |                   |
| `wellOracleSnapshot`         | `0x597490c0` | Replace | View |                   |
| `gm`                         | `0x64ee4b80` | Replace | Call | ✓                 |
| `sunrise`                    | `0xfc06d2a6` | Replace | Call |                   |

### Event Changes

None.

## Beans Minted

A total of 4,194.934459 Beans are minted to the Beanstalk contract ([0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5](https://etherscan.io/address/0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5)) to cover the remaining Beans removed from Beanstalk as a result of the issue fixed in EBIP-10.

## Effective

Effective immediately upon commitment by the BCM, which has already happened.
